### PR TITLE
Fix examples for format definitions, and add tombstone.

### DIFF
--- a/interchange/DeviceResources.capnp
+++ b/interchange/DeviceResources.capnp
@@ -170,6 +170,9 @@ struct Device {
     sites      @2 : List(Site);
     row        @3 : UInt16;
     col        @4 : UInt16;
+
+    # Field ordinal 5 was deleted.
+    deleted    @5 : UInt32;
   }
 
   ######################################
@@ -606,9 +609,9 @@ struct Device {
     verilogBinary @4;
     # 8'hF
     verilogHex    @5;
-    # 0xF
+    # 0b10
     cBinary       @6;
-    # 0.0
+    # 0xF
     cHex          @7;
   }
 


### PR DESCRIPTION
Fields in capnproto shouldn't be deleted for backwards compability
reasons.