### PR TITLE
Allow macro expansions conditional on parameter match

### DIFF
--- a/interchange/DeviceResources.capnp
+++ b/interchange/DeviceResources.capnp
@@ -242,6 +242,14 @@ struct Device {
   struct PrimToMacroExpansion {
     primName  @0 : StringIdx $stringRef();
     macroName @1 : StringIdx $stringRef();
+    # Optionally, primitive to macro expansions can be conditional on a
+    # parameter match. For example, I/O buffer expansions might be 
+    # different between true and pseudo differential IO types. The
+    # expansion is used if **any** of the parameters specified match.
+    union {
+      always     @2 : Void;
+      parameters @3 : List(Dir.Netlist.PropertyMap.Entry);
+    }
   }
 
   # Cell <-> BEL and Cell pin <-> BEL Pin mapping


### PR DESCRIPTION
To give a concrete example of why this is needed, consider the following design for `xczu2eg-sbva484-2-e` in Vivado:

```verilog
module top(
    input I,
    output O_SSTL, OB_SSTL,
    output O_LVDS, OB_LVDS
);
    OBUFDS buf_sstl (.I(I), .O(O_SSTL), .OB(OB_SSTL));
    OBUFDS buf_lvds (.I(I), .O(O_LVDS), .OB(OB_LVDS));
endmodule
```

```tcl
set_property IOSTANDARD LVCMOS18 [get_ports I]
set_property IOSTANDARD DIFF_SSTL18_I [get_ports O_SSTL]
set_property IOSTANDARD LVDS [get_ports O_LVDS]

set_property PACKAGE_PIN G5 [get_ports I]
set_property PACKAGE_PIN B2 [get_ports O_SSTL]
set_property PACKAGE_PIN T3 [get_ports O_LVDS]
```

Even though both the SSTL and LVDS output buffers are instantiated as `OBUFDS`, the SSTL buffer expands to `OBUFDS_DUAL_BUF` being pseudo-differential whereas the LVDS one remains as `OBUFDS`:
![Screenshot from 2021-04-22 10-30-48](https://user-images.githubusercontent.com/78621419/115691298-d4a40a00-a355-11eb-8704-1928d61d973f.png)

This adds support for this kind of conditionality to the interchange schema.
