### PR TITLE
Split wire/node mapping into a new schema

### DIFF
--- a/cmake/cxx_static/CMakeLists.txt
+++ b/cmake/cxx_static/CMakeLists.txt
@@ -1,5 +1,5 @@
 find_package(CapnProto REQUIRED)
-set(PROTOS LogicalNetlist.capnp PhysicalNetlist.capnp DeviceResources.capnp FlatWiresNodes.capnp References.capnp)
+set(PROTOS LogicalNetlist.capnp PhysicalNetlist.capnp DeviceResources.capnp  DedupWiresNodes.capnp FlatWiresNodes.capnp References.capnp)
 
 set(INTERCHANGE_SCHEMA_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../interchange)
 

--- a/cmake/cxx_static/CMakeLists.txt
+++ b/cmake/cxx_static/CMakeLists.txt
@@ -1,5 +1,5 @@
 find_package(CapnProto REQUIRED)
-set(PROTOS LogicalNetlist.capnp PhysicalNetlist.capnp DeviceResources.capnp References.capnp)
+set(PROTOS LogicalNetlist.capnp PhysicalNetlist.capnp DeviceResources.capnp FlatWiresNodes.capnp References.capnp)
 
 set(INTERCHANGE_SCHEMA_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../interchange)
 

--- a/interchange/DedupWiresNodes.capnp
+++ b/interchange/DedupWiresNodes.capnp
@@ -1,0 +1,61 @@
+# Copyright 2020-2021 Xilinx, Inc. and Google, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+@0x9d262c6ba6512325;
+using Java = import "/capnp/java.capnp";
+using Ref = import "References.capnp";
+$Java.package("com.xilinx.rapidwright.interchange");
+$Java.outerClassname("DedupWiresNodes");
+
+using Cxx = import "/capnp/c++.capnp";
+$Cxx.namespace("DedupWiresNodes");
+
+struct StringRef {
+    type  @0 :Ref.ReferenceType = rootValue;
+    field @1 :Text = "strList";
+}
+annotation stringRef(*) :StringRef;
+using StringIdx = UInt32;
+
+struct NodeShapeRef {
+    type  @0 :Ref.ReferenceType = parent;
+    field @1 :Text = "nodeShapes";
+    depth @2 :Int32 = 1;
+}
+annotation nodeShapeRef(*) :NodeShapeRef;
+using NodeShapeIdx = UInt32;
+
+# This structure describes a deduplicated wire-node mapping, as an interim step between a flat graph and a fully folded graph.
+# It requires a full list of nodes in the device and their "shape", but not a full list of wires within those nodes as nodes
+# with the same "shape", using relative coordinates, only have their list of constituent wires stored once.
+struct DedupWiresNodes {
+  nodes           @0 : List(Node);
+  nodeShapes      @1 : List(NodeShape);
+
+  struct Node {
+    rootTile  @0 : StringIdx $stringRef();
+    shape     @1 : NodeShapeIdx $nodeShapeRef();
+  }
+
+  struct NodeWire {
+    dx    @0 : Int16; # wire.x = rootTile.x + dx
+    dy    @1 : Int16; # wire.y = rootTile.y + dy
+    wire  @2 : StringIdx $stringRef();
+  }
+
+  struct NodeShape {
+    wires @0 : List(NodeWire);
+  }
+
+}

--- a/interchange/DeviceResources.capnp
+++ b/interchange/DeviceResources.capnp
@@ -141,6 +141,7 @@ struct Device {
     wires      @2 : List(StringIdx) $stringRef();
     pips       @3 : List(PIP);
     constants  @4 : List(WireConstantSources);
+    wireTypes  @5 : List(WireTypeIdx);
   }
 
   #######################################
@@ -216,7 +217,7 @@ struct Device {
   struct Wire {
     tile      @0 : StringIdx $stringRef();
     wire      @1 : StringIdx $stringRef();
-    type      @2 : WireTypeIdx $wireTypeRef();
+    deleted   @2 : Void;
   }
 
   enum WireCategory {

--- a/interchange/DeviceResources.capnp
+++ b/interchange/DeviceResources.capnp
@@ -50,14 +50,6 @@ struct BELPinRef {
 annotation belPinRef(*) :BELPinRef;
 using BELPinIdx = UInt32;
 
-struct WireRef {
-    type  @0 :Ref.ReferenceType = parent;
-    field @1 :Text = "wires";
-    depth @2 :Int32 = 1;
-}
-annotation wireRef(*) :WireRef;
-using WireIdx = UInt32;
-
 struct WireTypeRef {
     type  @0 :Ref.ReferenceType = parent;
     field @1 :Text = "wireTypes";
@@ -86,8 +78,8 @@ struct Device {
   siteTypeList    @2 : List(SiteType);
   tileTypeList    @3 : List(TileType);
   tileList        @4 : List(Tile);
-  wires           @5 : List(Wire);
-  nodes           @6 : List(Node);
+  deleted0        @5 : Void;
+  deleted1        @6 : Void;
   primLibs        @7 : Dir.Netlist; # Netlist libraries of Unisim primitives and macros
   exceptionMap    @8 : List(PrimToMacroExpansion); # Prims to macros expand w/same name, except these
   cellBelMap      @9 : List(CellBelMapping);
@@ -214,12 +206,6 @@ struct Device {
   # Inter-site routing resources
   ######################################
 
-  struct Wire {
-    tile      @0 : StringIdx $stringRef();
-    wire      @1 : StringIdx $stringRef();
-    deleted   @2 : Void;
-  }
-
   enum WireCategory {
     # general interconnect, usually with many uphill and downhill pips and spanning multiple tiles
     general @0;
@@ -236,10 +222,6 @@ struct Device {
   struct WireType {
     name     @0 : StringIdx $stringRef();
     category @1 : WireCategory;
-  }
-
-  struct Node {
-    wires    @0 : List(WireIdx) $wireRef();
   }
 
   struct PIP {

--- a/interchange/FlatWiresNodes.capnp
+++ b/interchange/FlatWiresNodes.capnp
@@ -1,0 +1,53 @@
+# Copyright 2020-2021 Xilinx, Inc. and Google, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+@0x9d262c6ba6512325;
+using Java = import "/capnp/java.capnp";
+using Ref = import "References.capnp";
+$Java.package("com.xilinx.rapidwright.interchange");
+$Java.outerClassname("FlatWiresNodes");
+
+using Cxx = import "/capnp/c++.capnp";
+$Cxx.namespace("FlatWiresNodes");
+
+struct StringRef {
+    type  @0 :Ref.ReferenceType = rootValue;
+    field @1 :Text = "strList";
+}
+annotation stringRef(*) :StringRef;
+using StringIdx = UInt32;
+
+struct WireRef {
+    type  @0 :Ref.ReferenceType = parent;
+    field @1 :Text = "wires";
+    depth @2 :Int32 = 1;
+}
+annotation wireRef(*) :WireRef;
+using WireIdx = UInt32;
+
+# This structure describes a flat wire-node mapping with no folding or deduplication
+struct FlatWiresNodes {
+  wires           @0 : List(Wire);
+  nodes           @1 : List(Node);
+
+  struct Wire {
+    tile      @0 : StringIdx $stringRef();
+    wire      @1 : StringIdx $stringRef();
+  }
+
+  struct Node {
+    wires    @0 : List(WireIdx) $wireRef();
+  }
+
+}


### PR DESCRIPTION
Following some IRC discussions with @mithro about different wire/node mapping representations, it was suggested that we could split that out of the main schema to make it easier to add new representations, like the future graph folding work from BYU.

At the moment, the wires/nodes are a totally separate schema but I'd be interested in knowing if there was a way of integrating it better.

Two examples are currently included, the original flat structure and my partially deduplicated structure from the tests in Xilinx/RapidWright#176 (towards the end of the discussion).