### PR TITLE
schema: physical: add site information to physicalPip

### DIFF
--- a/interchange/PhysicalNetlist.capnp
+++ b/interchange/PhysicalNetlist.capnp
@@ -131,6 +131,14 @@ struct PhysNetlist {
     wire1   @2 : StringIdx $stringRef();
     forward @3 : Bool;
     isFixed @4 : Bool;
+    # In case of a pseudo PIP also the traversed site
+    # needs to be added to the PhysPIP object
+    union {
+      noSite @5: Void;
+      # It is assumed that a pseudo PIP can traverse one
+      # site only
+      site   @6: StringIdx $stringRef();
+    }
   }
 
   struct PhysSitePIP {


### PR DESCRIPTION
While the traversed bels and the corresponding pins information is present in the `pseudoCells` data, the site instance information cannot be easily acquired from a pseudo tile PIP (considering a tile that has multiple sites).

This change adds the information on which site instance is used by the pseudo tile PIP.