### PR TITLE
interchange: Add sub-tiles, needed for Nexus FASM generation

### DIFF
--- a/interchange/DeviceResources.capnp
+++ b/interchange/DeviceResources.capnp
@@ -78,6 +78,7 @@ annotation tileTypeRef(*) :TileTypeRef;
 using TileTypeIdx = UInt32;
 
 using TileTypeSiteTypeIdx = UInt32;
+using TileTypeSubTileIdx = UInt16;
 
 struct Device {
 
@@ -185,6 +186,14 @@ struct Device {
 
     # Field ordinal 5 was deleted.
     deleted    @5 : UInt32;
+
+    # Sub-tiles enable PIPs inside a tile to use different FASM prefices
+    # This is needed for the Nexus, where there can be multiple tiles from a
+    # bitstream perspective at the same (row, col) grid location. PIP.subTile
+    # indexes into this list to get a prefix for FASM purposes.
+    # If sub-tiles are not used; then this list is empty and an implicit
+    # sub-tile index 0 has the same prefix as the tile name.
+    subTilesPrefices @6 : List(StringIdx) $stringRef();
   }
 
   ######################################
@@ -254,6 +263,7 @@ struct Device {
       conventional @5 : Void;
       pseudoCells  @6 : List(PseudoCell);
     }
+    subTile      @7 : TileTypeSubTileIdx; # Index into Tile.subTilesPrefices
   }
 
   struct PseudoCell {


### PR DESCRIPTION
This is the easiest way to implement FASM generation for the Nexus, and other devices that have a similar problem of multiple tiles at the same grid location (ECP5, MachXO2, etc):

![Screenshot from 2021-05-24 12-13-35](https://user-images.githubusercontent.com/78621419/119339757-7be3cc00-bc89-11eb-8ca2-c2efd14efab1.png)
